### PR TITLE
✅ Fix typo on WikidataValidateDeref.js

### DIFF
--- a/src/wikidata/WikidataValidateDeref.js
+++ b/src/wikidata/WikidataValidateDeref.js
@@ -285,7 +285,7 @@ function WikidataValidateDeref(props) {
 
     return (
        <Container>
-         <h1>Validate Wikidata entities (by Dererentiation)</h1>
+         <h1>Validate Wikidata entities (by Dereferencing)</h1>
                    { status.result || status.loading || status.error ?
                        <Row>
                            {status.loading ? <Pace color="#27ae60"/> :


### PR DESCRIPTION
Issue #14 indicates that there exists a typo in the WikidataValidateDeref javascript file. The typo was that the word Dereferencing was writen as _Dererentiation_.

**Previous version**
https://github.com/weso/wikishape/blob/12fd7b338e87b043c7eb393d8cc47753247523de/src/wikidata/WikidataValidateDeref.js#L288

**Changes**
* Changes line 288 from `<h1>Validate Wikidata entities (by Dererentiation)</h1>` to `<h1>Validate Wikidata entities (by Dereferencing)</h1>`.
* Fixes #14.