### PR TITLE
GitHub action for automated builds/publishments

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,19 +3,18 @@ on:
   # Manual trigger
   workflow_dispatch:
 
-  # Trigger on push to main
   push:
     branches:
       - main
       - master
-  # Trigger on PR merging to main
+
   pull_request:
     branches:
       - main
       - master
 
 jobs:
-  test:
+  build_and_test:
     name: Build and test the application
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,35 @@
+name: Publish Docker image
+on:
+  # Manual trigger
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry
+    if: ${{ github.repository_owner == 'weso' }} # Do not run in forks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to GitHub Container Registry
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/weso/wikishape:${{ github.sha }}
+
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN npm run build
 
 ## Prod environment.
 FROM nginx:stable-alpine as prod
+LABEL org.opencontainers.image.source="https://github.com/weso/wikishape"
 WORKDIR /usr/share/nginx/html
 
 # Add bash


### PR DESCRIPTION
Created an automated workflow that builds and pushes Docker images of wikishape on pushes to the main repository's branch. New images are tagged with the hash of the commit that creates them.

See published images: https://github.com/orgs/weso/packages/container/package/wikishape

Related: weso/rdfshape#239